### PR TITLE
Fix GitHub Actions OOM error by running on macOS 11

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
   # This workflow contains a single job called "data-update"
   update-trends-data:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: macos-11
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
   # This workflow contains a single job called "data-update"
   update-trends-data:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: macos-11
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
This fixes frequent out-of-memory errors in our GitHub Actions workflow (#25), by running on macOS instead of Ubuntu. 


Per [docs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources), macOS runners have 4 GB RAM compared to Ubuntu's 2 GB.  [Here is an example Gene Hints workflow](https://github.com/broadinstitute/gene-hints/runs/4357780729?check_suite_focus=true) that succeeded with this approach.